### PR TITLE
When TerminalNode is null - 'other' menu is not working

### DIFF
--- a/LethalCompanyMonitorMod/Patch/TerminalPatch.cs
+++ b/LethalCompanyMonitorMod/Patch/TerminalPatch.cs
@@ -20,7 +20,7 @@ namespace LethalCompanyMonitorMod.Patch
         [HarmonyPostfix]
         private static void HandleSentence(Terminal __instance, TerminalNode __result)
         {
-            if (!__instance.terminalInUse || Plugin.ViewMonitorSubmitted)
+            if (__result == null || !__instance.terminalInUse || Plugin.ViewMonitorSubmitted)
                 return;
 
             if (String.Compare(__result.name, "ViewInsideShipCam 1", true) == 0)


### PR DESCRIPTION
It's related to both mods together, as ExtraDaysToDeadline uses a terminal library so it might be the combination of all of them together. I added a condition to verify if the TerminalNode reference is not null, as it is also a good fail-safe with other mods that might tweak the terminal commands/interface.